### PR TITLE
Add config option to set VTE word character exceptions.

### DIFF
--- a/config
+++ b/config
@@ -12,6 +12,7 @@ font = Monospace 9
 #mouse_autohide = false
 #scroll_on_output = false
 #scroll_on_keystroke = true
+word_char_exceptions = -=&#:/.?@+~_%;
 # Length of the scrollback buffer, 0 disabled the scrollback buffer
 # and setting it to a negative value means "infinite scrollback"
 scrollback_lines = 10000

--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -17,6 +17,8 @@ Display bold text in bright colors.
 .IP \fIbrowser\fR
 Set the default browser for opening links. If its not set,
 \fI$BROWSER\fR is read. If that's not set, url hints will be disabled.
+.IP \fIword_char_exceptions\fR
+Set characters to exclude as word boundaries on selection;
 .IP \fIclickable_url\fR
 Auto-detected URLs can be clicked on to open them in your browser. Only
 enabled if a browser is configured or detected.

--- a/termite.cc
+++ b/termite.cc
@@ -1535,6 +1535,10 @@ static void set_config(GtkWindow *window, VteTerminal *vte, GtkWidget *scrollbar
         info->tag = -1;
     }
 
+    if (auto s = get_config_string(config, "options", "word_char_exceptions")) {
+        vte_terminal_set_word_char_exceptions(vte, *s);
+    }
+
     if (auto s = get_config_string(config, "options", "font")) {
         PangoFontDescription *font = pango_font_description_from_string(*s);
         vte_terminal_set_font(vte, font);


### PR DESCRIPTION
Fixes #696.