### PR TITLE
README: Update terminfo instructions pipe the output of curl.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,5 +209,4 @@ On other systems:
 
 ::
 
-    wget https://raw.githubusercontent.com/thestinger/termite/master/termite.terminfo
-    tic -x termite.terminfo
+    curl https://raw.githubusercontent.com/thestinger/termite/master/termite.terminfo | tic -x -


### PR DESCRIPTION
This is instead of using wget, so that a file is not downloaded.